### PR TITLE
Add pseudoClasses option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,12 @@ i.e.
 }
 ```
 
+### pseudoClasses
+
+Type `boolean`
+Default: `false`
+
+If this is true then pseudo classes (`&:hover`, `&:focus`) are included in the parent chain
+
 ## Todo's
 - Add warning when nestingLevel >= parentsStack.length

--- a/README.md
+++ b/README.md
@@ -111,5 +111,42 @@ Default: `&`
 
 Ancestor selector base symbol
 
+### replaceValues
+
+Type `boolean`
+Default: `false`
+
+If this is true then this plugin will look through your declaration values for the placeholder symbol and replace them with the desired selector.
+
+i.e.
+
+```css
+.foo {
+    background-color: red;
+
+    &:hover {
+        background-color: blue;
+
+        &::before {
+            content: '^&';
+        }
+    }
+}
+```
+
+```
+.foo {
+  background-color: red;
+}
+
+.foo:hover {
+ background-color: blue;
+}
+
+.foo:hover::before {
+ content: '.foo'
+}
+```
+
 ## Todo's
 - Add warning when nestingLevel >= parentsStack.length

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
     function getParentSelectorAtLevel(nestingLevel) {
         nestingLevel = nestingLevel || 1;
 
-        if (opts.pseudoClasses) nestingLevel -= 1
+        if (opts.pseudoClasses) nestingLevel -= 1;
 
         // @TODO add warning when nestingLevel >= parentsStack.length
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var postcss = require('postcss'),
 
 module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
     opts = assign({
-        placeholder: '^&'
+        placeholder: '^&',
+        replaceValues: false
     }, opts);
 
     // Advanced options
@@ -84,6 +85,16 @@ module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
 
                 // Replace parents placeholders in rule selector
                 rule.selectors = rule.selectors.map(replacePlaceholders);
+
+                if (opts.replaceValues) {
+                    rule.nodes.forEach(function (node) {
+                        if (node.type === 'decl') {
+                            if (node.value.indexOf(opts.placeholder) >= 0) {
+                                node.value = replacePlaceholders(node.value);
+                            }
+                        }
+                    })
+                }
 
                 // Process child rules
                 process(rule);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var postcss = require('postcss'),
 module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
     opts = assign({
         placeholder: '^&',
-        replaceValues: false
+        replaceValues: false,
+        pseudoClasses: false
     }, opts);
 
     // Advanced options
@@ -34,6 +35,8 @@ module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
      */
     function getParentSelectorAtLevel(nestingLevel) {
         nestingLevel = nestingLevel || 1;
+
+        if (opts.pseudoClasses) nestingLevel -= 1
 
         // @TODO add warning when nestingLevel >= parentsStack.length
 

--- a/index.js
+++ b/index.js
@@ -87,13 +87,15 @@ module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
                 rule.selectors = rule.selectors.map(replacePlaceholders);
 
                 if (opts.replaceValues) {
-                    rule.nodes.forEach(function (node) {
-                        if (node.type === 'decl') {
-                            if (node.value.indexOf(opts.placeholder) >= 0) {
-                                node.value = replacePlaceholders(node.value);
+                    rule.nodes.forEach(function (ruleNode) {
+                        if (ruleNode.type === 'decl') {
+                            if (ruleNode.value.indexOf(opts.placeholder) >= 0) {
+                                ruleNode.value = replacePlaceholders(
+                                    ruleNode.value
+                                );
                             }
                         }
-                    })
+                    });
                 }
 
                 // Process child rules

--- a/test.js
+++ b/test.js
@@ -51,6 +51,16 @@ test('Replace declaration values if replaceValues is true', t => {
     );
 });
 
+test('Take into account pseudo classes if pseudoClasses is true', t => {
+    return run( t,
+                '.a{ background: red; &:hover {&::before ' +
+                '{ content: "^&"; }}}',
+                '.a{ background: red; &:hover {&::before ' +
+                '{ content: ".a:hover"; }}}',
+                { replaceValues: true, pseudoClasses: true }
+    );
+});
+
 test('Replace ancestors at different nesting levels', t => {
     return run( t,
                 '.a{ &:hover{ ^&-b{} } .c{ .d{ ^&-e{} } } .z{} }',

--- a/test.js
+++ b/test.js
@@ -43,6 +43,14 @@ test('Prepend 2 ancestors in double selector', t => {
     );
 });
 
+test('Replace declaration values if replaceValues is true', t => {
+    return run( t,
+                '.a{ background: red; &:hover {&::before { content: "^&"; }}}',
+                '.a{ background: red; &:hover {&::before { content: ".a"; }}}',
+                { replaceValues: true }
+    );
+});
+
 test('Replace ancestors at different nesting levels', t => {
     return run( t,
                 '.a{ &:hover{ ^&-b{} } .c{ .d{ ^&-e{} } } .z{} }',


### PR DESCRIPTION
If this is true then pseudo classes (`&:hover`, `&:focus`) are included in the parent chain

This would need to be merged after #2 as it includes #2 commits in this as well :)