### PR TITLE
Resolve complex nesting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,12 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline = false
 
 [*.{json,yml}]
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 npm-debug.log
 coverage.lcov
 coverage/
-.nyc_output
+.nyc_output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 npm-debug.log
+coverage.lcov
+coverage/
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,6 @@ npm-debug.log
 
 test.js
 .travis.yml
+coverage.lcov
+coverage/
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - npm install
   - npm install -g codecov
 script:
+  - npm run build
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ install:
   - npm install
   - npm install -g codecov
 script:
-  - npm test
-  - codecov
+  - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ install:
   - npm install
   - npm install -g codecov
 script:
-  - npm test
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
 language: node_js
 node_js:
   - "6"
-  - "4"
-  - "0.12"
-notifications:
-  email:
-    on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - "6"
+install:
+  - npm install
+  - npm install -g codecov
+script:
+  - npm test
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - npm install
   - npm install -g codecov
 script:
+  - npm test
   - npm run report-coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PostCSS Nested Selectors
 [![Build Status](https://travis-ci.org/nathanhood/postcss-nested-selectors.svg?branch=master)](https://travis-ci.org/nathanhood/postcss-nested-selectors)
+[![codecov](https://codecov.io/gh/nathanhood/postcss-nested-selectors/branch/master/graph/badge.svg)](https://codecov.io/gh/nathanhood/postcss-nested-selectors)
+
 
 **Note:** This is a fork of [postcss-nested-selectors](https://github.com/nathanhood/postcss-nested-selectors).
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# PostCSS Nested ancestors [![Build Status][ci-img]][ci]
+# PostCSS Nested ancestors
+
+**Note:** This is a fork of [postcss-nested-ancestors](https://github.com/toomuchdesign/postcss-nested-ancestors).
 
 [PostCSS] plugin to reference any ancestor selector in nested CSS.
 
-[PostCSS]:                      https://github.com/postcss/postcss
-[ci-img]:                       https://travis-ci.org/toomuchdesign/postcss-nested-ancestors.svg
-[ci]:                           https://travis-ci.org/toomuchdesign/postcss-nested-ancestors
-[postcss-current-selector]:     https://github.com/komlev/postcss-current-selector
-[postcss-nested]:               https://github.com/postcss/postcss-nested
-[postcss-simple-vars]:          https://github.com/postcss/postcss-simple-vars
+[PostCSS]: https://github.com/postcss/postcss
+[postcss-current-selector]: https://github.com/komlev/postcss-current-selector
+[postcss-nested]: https://github.com/postcss/postcss-nested
+[postcss-simple-vars]: https://github.com/postcss/postcss-simple-vars
 
 ## Getting ancestor selectors
 When writing modular nested CSS, `&` current parent selector is often not enough.
@@ -21,7 +21,7 @@ See [PostCSS] docs for examples for your environment.
 ### Ancestor selectors schema
 
 ```
-    .level-1 {
+	.level-1 {
 |   |   .level-2 {
 |   |   |   .level-3 {
 |   |   |   |   .level-4 {
@@ -31,10 +31,10 @@ See [PostCSS] docs for examples for your environment.
 |   |   ----------- ^^& {}      /*    ^^& = ".level-1 .level-2"                   */
 |   --------------- ^^^& {}     /*   ^^^& = ".level-1"                            */
 ------------------- ^^^^& {}    /*  ^^^^& = ""                                    */
-                }
-            }
-        }
-    }
+				}
+			}
+		}
+	}
 ```
 
 ### A real example
@@ -42,25 +42,25 @@ See [PostCSS] docs for examples for your environment.
 ```css
 /* Without postcss-nested-ancestors */
 .MyComponent
-    &-part{}
-    &:hover {
-        > .MyComponent-part {} /* Must manually repeat ".MyComponent" for each child */
-    }
+	&-part{}
+	&:hover {
+		> .MyComponent-part {} /* Must manually repeat ".MyComponent" for each child */
+	}
 }
 
 /* With postcss-nested-ancestors */
 .MyComponent
-    &-part{}
-    &:hover {
-        > ^&-part {} /* Skip ":hover" inheritance here */
-    }
+	&-part{}
+	&:hover {
+		> ^&-part {} /* Skip ":hover" inheritance here */
+	}
 }
 
 /* After postcss-nested-ancestors */
 .MyComponent {
-    &-part{}
-    &:hover {
-        > .MyComponent-part {}
+	&-part{}
+	&:hover {
+		> .MyComponent-part {}
 }
 
 /* After postcss-nested */
@@ -110,58 +110,3 @@ Type: `string`
 Default: `&`
 
 Ancestor selector base symbol
-
-### replaceDeclarations (experimental)
-
-Type: `boolean`
-Default: `false`
-
-If this is true then this plugin will look through your declaration values/properties for the placeholder symbol and replace them with specified selector.
-
-An use case for this if enabling [postcss-ref](https://github.com/morishitter/postcss-ref) to work with dynamic `@ref` selectors. Read discussion [here](https://github.com/toomuchdesign/postcss-nested-ancestors/pull/3).
-
-```css
-/* Before */
-.foo {
-    &:last-child {
-        border-top: ref(^&, border-bottom);
-    }
-}
-
-/* After PostCSS Nested ancestors and PostCSS Nested */
-.foo {
-}
-
-.foo:last-child {
-    border-top: ref(.foo, border-bottom);
-}
-```
-
-## Known issues
-
-### Complex nesting
-**PostCSS Nested ancestors** is currently not able to resolve complex nesting cases like multiple selector declarations. It might break badly.
-
-```css
-/* Before */
-.foo,
-.bar {
-    &:hover {
-        ^&-moo {
-        }
-    }
-}
-
-/* After :-( */
-.foo,
-.bar {
-    &:hover {
-        .foo,.bar-moo {
-        }
-    }
-}
-
-```
-
-## Todo's
-* Find a smart way to resolve complex nesting issues

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PostCSS Nested Selectors
+[![Build Status](https://travis-ci.org/nathanhood/postcss-nested-selectors.svg?branch=master)](https://travis-ci.org/nathanhood/postcss-nested-selectors)
 
 **Note:** This is a fork of [postcss-nested-selectors](https://github.com/nathanhood/postcss-nested-selectors).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PostCSS Nested ancestors
+# PostCSS Nested Selectors
 
-**Note:** This is a fork of [postcss-nested-ancestors](https://github.com/toomuchdesign/postcss-nested-ancestors).
+**Note:** This is a fork of [postcss-nested-selectors](https://github.com/nathanhood/postcss-nested-selectors).
 
 [PostCSS] plugin to reference any ancestor selector in nested CSS.
 
@@ -12,7 +12,7 @@
 ## Getting ancestor selectors
 When writing modular nested CSS, `&` current parent selector is often not enough.
 
-**PostCSS Nested ancestors** introduces `^&` selector which let you reference **any parent ancestor selector** with an easy and customizable interface.
+**PostCSS Nested Selectors** introduces `^&` selector which let you reference **any parent ancestor selector** with an easy and customizable interface.
 
 This plugin should be used **before** a POSTCSS rules unwrapper like [postcss-nested].
 
@@ -40,7 +40,7 @@ See [PostCSS] docs for examples for your environment.
 ### A real example
 
 ```css
-/* Without postcss-nested-ancestors */
+/* Without postcss-nested-selectors */
 .MyComponent
 	&-part{}
 	&:hover {
@@ -48,7 +48,7 @@ See [PostCSS] docs for examples for your environment.
 	}
 }
 
-/* With postcss-nested-ancestors */
+/* With postcss-nested-selectors */
 .MyComponent
 	&-part{}
 	&:hover {
@@ -56,7 +56,7 @@ See [PostCSS] docs for examples for your environment.
 	}
 }
 
-/* After postcss-nested-ancestors */
+/* After postcss-nested-selectors */
 .MyComponent {
 	&-part{}
 	&:hover {
@@ -74,18 +74,18 @@ See [PostCSS] docs for examples for your environment.
 ## Why?
 Currently another plugin - [postcss-current-selector] - has tried to solve the problem of referencing ancestors selector. It works great, but its approach involves assigning ancestor selectors to special variables to be later processed by a further postcss plugin [postcss-simple-vars].
 
-**PostCSS Nested ancestors** instead replaces special ancestor selectors, makes no use of variable assignment and produces an output ready to be unwrapped with [postcss-nested].
+**PostCSS Nested Selectors** instead replaces special ancestor selectors, makes no use of variable assignment and produces an output ready to be unwrapped with [postcss-nested].
 
 ## Installation
 
 ```console
-$ npm install postcss-nested-ancestors
+$ npm install postcss-nested-selectors
 ```
 
 ## Usage
 
 ```js
-postcss([ require('postcss-nested-ancestors') ]);
+postcss([ require('postcss-nested-selectors') ]);
 ```
 
 ## Options

--- a/index.js
+++ b/index.js
@@ -1,100 +1,80 @@
 var postcss = require('postcss'),
-	assign = require('object-assign'),
 	escRgx = require('escape-string-regexp');
 
-module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
-	opts = assign({
-		placeholder: '^&',
-		replaceDeclarations: false
-	}, opts);
-
-	// Advanced options
-	opts = assign({
-		levelSymbol: opts.levelSymbol || opts.placeholder.charAt(0),
-		parentSymbol: opts.parentSymbol || opts.placeholder.charAt(1)
+module.exports = postcss.plugin('postcss-nested-ancestors', opts => {
+	opts = Object.assign({
+		levelSymbol: opts.levelSymbol || '^',
+		parentSymbol: opts.parentSymbol || '&',
+		placeholder: '^&'
 	}, opts);
 
 	var parentStack = [],
-
-		// Get all ancestors placeholder recurrencies: ^&, ^^&, ^^^&, [...]
 		placeholderRegex = new RegExp(
-			// eslint-disable-next-line max-len
 			'([' + escRgx(opts.levelSymbol) + ']+)(' + escRgx(opts.parentSymbol) + ')(.*)',
 			'g'
 		),
-
-		// Get any space preceding an ampersand
 		spacesAndAmpersandRegex = /\s&/g;
 
 	/**
-	 * Walk current ancestor stack and
-	 * assembly ancestor selector at the given depth.
+	 * Determine how many level symbols ('^') exist
 	 *
-	 * @param  {Number} ancestor nesting depth (0 = &, 1 = ^& = grandparent...)
-	 * @param  {Object} a PostCSS Rule object
-	 * @param  {Object} a PostCSS Result object
-	 * @return {String} ancestor selector
+	 * @param {string} levelSymbol
+	 * @returns {number}
 	 */
-	function getParentSelectorAtLevel(nestingLevel, rule, result) {
-		nestingLevel = nestingLevel || 1;
+	function getNestingLevel(levelSymbol) {
+		return levelSymbol.split(opts.levelSymbol).length - 1 || 1
+	}
+
+	/**
+	 * Find parent selector from corresponding level symbol
+	 *
+	 * @param  {number} levelSymbol - Ancestor nesting depth (0 = &, 1 = ^&)
+	 * @param  {object} rule - PostCSS Rule object
+	 * @param  {object} result - PostCSS Result object
+	 * @return {string}
+	 */
+	function getParentSelector(levelSymbol, rule, result) {
+		let nestingLevel = getNestingLevel(levelSymbol);
 
 		// Set a warning when nestingLevel >= parentStack.length
 		if ( nestingLevel >= parentStack.length ) {
 			rule.warn(result, 'Parent selector exceeds current stack.');
 		}
 
-		// Create an array of matching parent selectors
-		return parentStack.filter( function (selector, index) {
-			return index < parentStack.length - nestingLevel;
-		})
+		return parentStack.filter((selector, index) => {
+				return index < parentStack.length - nestingLevel;
+			})
 			.join(' ')
-			.replace(spacesAndAmpersandRegex, '');  // Remove " &"
+			.replace(spacesAndAmpersandRegex, '');
 	}
 
 	/**
-	 * Given an ancestor placeholder,
-	 * returns the corresponding selector fragment.
-	 * Used as replacer in .replace method
+	 * Replace any ancestor placeholder into given selector(s)/string.
 	 *
-	 * @param  {String} levelSymbol (eg.^^)
-	 * @param  {Object} a PostCSS Rule object
-	 * @param  {Object} a PostCSS Result object
-	 * @return {String} string      ancestor selector fragment
-	 */
-	function placeholderReplacer(levelSymbol, rule, result) {
-		return getParentSelectorAtLevel(
-
-			// Determine how many level symbols ("^") there are
-			levelSymbol.split(opts.levelSymbol).length - 1,
-			rule,
-			result
-		);
-	}
-
-	/**
-	 * Replace any ancestor placeholder into a given selector/string.
-	 *
-	 * @param  {String} CSS selector / string
-	 * @param  {Object} a PostCSS Rule object
-	 * @param  {Object} a PostCSS Result object
-	 * @return {String} selector
+	 * @param  {string} selector - CSS selector
+	 * @param  {object} rule - PostCSS Rule object
+	 * @param  {object} result - PostCSS Result object
+	 * @return {string}
 	 */
 	function replacePlaceholders(selector, rule, result) {
-		return selector.split(/,\s*/).map(function (sel) {
-			return sel.replace(
-				placeholderRegex,
-				function (m, levelSymbol, parentSymbol, end) {
-					return placeholderReplacer(levelSymbol, rule, result)
-						.split(/,\s*/)
-						.map(function (parent) {
-							return parent + end;
-						}).join(', ');
-				}
-			);
-		}).join(', ');
+		return selector.split(/,\s*/)
+			.map(sel => {
+				return sel.replace(
+					placeholderRegex,
+					(m, levelSymbol, parentSymbol, end) => {
+						return getParentSelector(levelSymbol, rule, result)
+							.split(/,\s*/)
+							.map(parent => {
+								return parent + end;
+							})
+							.join(', ');
+					}
+				);
+			})
+			.join(', ');
 	}
 
-	var process = function (node, result) {
+	function process(node, result) {
 		node.walkRules(rule => {
 			// Replace parent placeholders in rule selectors
 			rule.selector = replacePlaceholders(rule.selector, rule, result);
@@ -110,7 +90,7 @@ module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
 		parentStack.pop();
 	};
 
-	return function (root, result) {
+	return (root, result) => {
 		process(root, result);
 	};
 });

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 var postcss = require('postcss'),
 	escRgx = require('escape-string-regexp');
 
-module.exports = postcss.plugin('postcss-nested-ancestors', opts => {
+module.exports = postcss.plugin('postcss-nested-ancestors', (opts = {}) => {
 	opts = Object.assign({
-		levelSymbol: opts.levelSymbol || '^',
-		parentSymbol: opts.parentSymbol || '&',
-		placeholder: '^&'
+		placeholder: '^&',
+		replaceDeclarations: false
+	}, opts);
+
+	// Advanced options
+	opts = Object.assign({
+		levelSymbol: opts.levelSymbol || opts.placeholder.charAt(0),
+		parentSymbol: opts.parentSymbol || opts.placeholder.charAt(1)
 	}, opts);
 
 	var parentStack = [],

--- a/index.js
+++ b/index.js
@@ -1,126 +1,116 @@
 var postcss = require('postcss'),
-    assign = require('object-assign'),
-    escRgx = require('escape-string-regexp');
+	assign = require('object-assign'),
+	escRgx = require('escape-string-regexp');
 
 module.exports = postcss.plugin('postcss-nested-ancestors', function (opts) {
-    opts = assign({
-        placeholder: '^&',
-        replaceDeclarations: false
-    }, opts);
+	opts = assign({
+		placeholder: '^&',
+		replaceDeclarations: false
+	}, opts);
 
-    // Advanced options
-    opts = assign({
-        levelSymbol: opts.levelSymbol || opts.placeholder.charAt(0),
-        parentSymbol: opts.parentSymbol || opts.placeholder.charAt(1)
-    }, opts);
+	// Advanced options
+	opts = assign({
+		levelSymbol: opts.levelSymbol || opts.placeholder.charAt(0),
+		parentSymbol: opts.parentSymbol || opts.placeholder.charAt(1)
+	}, opts);
 
-    var parentsStack = [],
+	var parentStack = [],
 
-        // Get all ancestors placeholder recurrencies: ^&, ^^&, ^^^&, [...]
-        placeholderRegex = new RegExp(
-            // eslint-disable-next-line max-len
-            '([' + escRgx(opts.levelSymbol) + ']+)(' + escRgx(opts.parentSymbol) + ')(.*)',
-            'g'
-        ),
+		// Get all ancestors placeholder recurrencies: ^&, ^^&, ^^^&, [...]
+		placeholderRegex = new RegExp(
+			// eslint-disable-next-line max-len
+			'([' + escRgx(opts.levelSymbol) + ']+)(' + escRgx(opts.parentSymbol) + ')(.*)',
+			'g'
+		),
 
-        // Get any space preceding an ampersand
-        spacesAndAmpersandRegex = /\s&/g;
+		// Get any space preceding an ampersand
+		spacesAndAmpersandRegex = /\s&/g;
 
-    /**
-     * Walk current ancestor stack and
-     * assembly ancestor selector at the given depth.
-     *
-     * @param  {Number} ancestor nesting depth (0 = &, 1 = ^& = grandparent...)
-     * @param  {Object} a PostCSS Rule object
-     * @param  {Object} a PostCSS Result object
-     * @return {String} ancestor selector
-     */
-    function getParentSelectorAtLevel(nestingLevel, rule, result) {
-        nestingLevel = nestingLevel || 1;
+	/**
+	 * Walk current ancestor stack and
+	 * assembly ancestor selector at the given depth.
+	 *
+	 * @param  {Number} ancestor nesting depth (0 = &, 1 = ^& = grandparent...)
+	 * @param  {Object} a PostCSS Rule object
+	 * @param  {Object} a PostCSS Result object
+	 * @return {String} ancestor selector
+	 */
+	function getParentSelectorAtLevel(nestingLevel, rule, result) {
+		nestingLevel = nestingLevel || 1;
 
-        // Set a warning when nestingLevel >= parentsStack.length
-        if ( nestingLevel >= parentsStack.length ) {
-            rule.warn(result, 'Parent selector exceeds current stack.');
-        }
+		// Set a warning when nestingLevel >= parentStack.length
+		if ( nestingLevel >= parentStack.length ) {
+			rule.warn(result, 'Parent selector exceeds current stack.');
+		}
 
-        // Create an array of matching parent selectors
-        return parentsStack.filter( function (selector, index) {
-            return index < parentsStack.length - nestingLevel;
-        })
-            .join(' ')
-            .replace(spacesAndAmpersandRegex, '');  // Remove " &"
-    }
+		// Create an array of matching parent selectors
+		return parentStack.filter( function (selector, index) {
+			return index < parentStack.length - nestingLevel;
+		})
+			.join(' ')
+			.replace(spacesAndAmpersandRegex, '');  // Remove " &"
+	}
 
-    /**
-     * Given an ancestor placeholder,
-     * returns the corresponding selector fragment.
-     * Used as replacer in .replace method
-     *
-     * @param  {String} levelSymbol (eg.^^)
-     * @param  {Object} a PostCSS Rule object
-     * @param  {Object} a PostCSS Result object
-     * @return {String} string      ancestor selector fragment
-     */
-    function placeholderReplacer(levelSymbol, rule, result) {
-        return getParentSelectorAtLevel(
+	/**
+	 * Given an ancestor placeholder,
+	 * returns the corresponding selector fragment.
+	 * Used as replacer in .replace method
+	 *
+	 * @param  {String} levelSymbol (eg.^^)
+	 * @param  {Object} a PostCSS Rule object
+	 * @param  {Object} a PostCSS Result object
+	 * @return {String} string      ancestor selector fragment
+	 */
+	function placeholderReplacer(levelSymbol, rule, result) {
+		return getParentSelectorAtLevel(
 
-            // Determine how many level symbols ("^") there are
-            levelSymbol.split(opts.levelSymbol).length - 1,
-            rule,
-            result
-        );
-    }
+			// Determine how many level symbols ("^") there are
+			levelSymbol.split(opts.levelSymbol).length - 1,
+			rule,
+			result
+		);
+	}
 
-    /**
-     * Replace any ancestor placeholder into a given selector/string.
-     *
-     * @param  {String} CSS selector / string
-     * @param  {Object} a PostCSS Rule object
-     * @param  {Object} a PostCSS Result object
-     * @return {String} selector
-     */
-    function replacePlaceholders(selector, rule, result) {
-        return selector.split(/,\s*/).map(function (sel) {
-            return sel.replace(
-                placeholderRegex,
-                function (m, levelSymbol, parentSymbol, end) {
-                    return placeholderReplacer(levelSymbol, rule, result)
-                        .split(/,\s*/)
-                        .map(function (parent) {
-                            return parent + end;
-                        }).join(', ');
-                }
-            );
-        }).join(', ');
-    }
+	/**
+	 * Replace any ancestor placeholder into a given selector/string.
+	 *
+	 * @param  {String} CSS selector / string
+	 * @param  {Object} a PostCSS Rule object
+	 * @param  {Object} a PostCSS Result object
+	 * @return {String} selector
+	 */
+	function replacePlaceholders(selector, rule, result) {
+		return selector.split(/,\s*/).map(function (sel) {
+			return sel.replace(
+				placeholderRegex,
+				function (m, levelSymbol, parentSymbol, end) {
+					return placeholderReplacer(levelSymbol, rule, result)
+						.split(/,\s*/)
+						.map(function (parent) {
+							return parent + end;
+						}).join(', ');
+				}
+			);
+		}).join(', ');
+	}
 
-    var process = function (node, result) {
-        node.each( function (rule) {
-            if (rule.type === 'rule') {
+	var process = function (node, result) {
+		node.walkRules(rule => {
+			// Replace parent placeholders in rule selectors
+			rule.selector = replacePlaceholders(rule.selector, rule, result);
 
-                // Replace parents placeholders in rule selectors
-                rule.selector = replacePlaceholders(rule.selector, rule, result);
+			// Add selector to current parent stack
+			parentStack.push(rule.selector);
 
-                // Add current selector to current parent stack
-                parentsStack.push(rule.selector);
+			// Process child rules
+			process(rule, result);
+		});
 
-                // Process child rules
-                process(rule, result);
-            }
+		// Remove current parent stack item at the end of each child iteration
+		parentStack.pop();
+	};
 
-            // Optionally replace parents placeholders into declarations
-            // eslint-disable-next-line brace-style
-            else if (opts.replaceDeclarations && rule.type === 'decl') {
-                rule.value = replacePlaceholders(rule.value, rule, result);
-                rule.prop = replacePlaceholders(rule.prop, rule, result);
-            }
-        });
-
-        // Remove current parent stack item at the end of each child iteration
-        parentsStack.pop();
-    };
-
-    return function (root, result) {
-        process(root, result);
-    };
+	return function (root, result) {
+		process(root, result);
+	};
 });

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   ],
   "author": "Nathan Hood",
   "license": "MIT",
-  "repository": "toomuchdesign/postcss-nested-ancestors",
+  "repository": "nathanhood/postcss-nested-ancestors",
   "bugs": {
-    "url": "https://github.com/toomuchdesign/postcss-nested-ancestors/issues"
+    "url": "https://github.com/nathanhood/postcss-nested-ancestors/issues"
   },
-  "homepage": "https://github.com/toomuchdesign/postcss-nested-ancestors",
+  "homepage": "https://github.com/nathanhood/postcss-nested-ancestors",
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "postcss": "^5.0.21"

--- a/package.json
+++ b/package.json
@@ -23,11 +23,14 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
+    "babel-cli": "^6.18.0",
     "eslint": "^2.10.0",
-    "eslint-config-postcss": "^2.0.2"
+    "eslint-config-postcss": "^2.0.2",
+    "nyc": "^10.0.0"
   },
   "scripts": {
-    "test": "ava",
+    "build": "babel --out-dir=dist index.js",
+    "test": "nyc ava --reporter=text-lcov",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"
@@ -40,5 +43,22 @@
         90
       ]
     }
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ],
+    "plugins": [
+      "transform-runtime"
+    ],
+    "ignore": "test.js",
+    "env": {
+      "development": {
+        "sourceMaps": "inline"
+      }
+    }
+  },
+  "ava": {
+	"require": ["babel-core/register"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "babel --out-dir=dist index.js",
     "test": "nyc ava --reporter=lcov",
-    "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
+    "report-coverage": "nyc ava --reporter=lcov > coverage.lcov && codecov",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"
@@ -46,12 +46,8 @@
     }
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "transform-runtime"
-    ],
+    "presets": ["es2015"],
+    "plugins": ["transform-runtime"],
     "ignore": "test.js",
     "env": {
       "development": {
@@ -61,12 +57,5 @@
   },
   "ava": {
 	"require": ["babel-core/register"]
-  },
-  "nyc": {
-	"include": ["./test.js"],
-    "reporter": [
-	  "lcov",
-	  "text-summary"
-    ],
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,12 @@
   },
   "ava": {
 	"require": ["babel-core/register"]
+  },
+  "nyc": {
+	"include": ["./test.js"],
+    "reporter": [
+	  "lcov",
+	  "text-summary"
+    ],
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "babel --out-dir=dist index.js",
     "test": "nyc ava --reporter=lcov",
-    "report-coverage": "npm report --reporter=lcov > coverage.lcov && codecov",
+    "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "postcss-nested-ancestors",
+  "name": "postcss-nested-selectors",
   "version": "0.1.0",
-  "description": "PostCSS plugin to reference any ancestor selector in nested CSS",
+  "description": "PostCSS plugin to reference ancestor selectors",
   "keywords": [
     "postcss",
     "css",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "babel --out-dir=dist index.js",
     "test": "nyc ava --reporter=text-lcov",
+    "report-coverage": "npm test > coverage.lcov && codecov",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "css",
     "postcss-plugin",
     "ancestor",
-    "grandparent",
     "selector",
     "postcss-nested"
   ],
-  "author": "Andrea Carraro <me@andreacarraro.it>",
+  "author": "Nathan Hood",
   "license": "MIT",
   "repository": "toomuchdesign/postcss-nested-ancestors",
   "bugs": {
@@ -20,7 +19,6 @@
   "homepage": "https://github.com/toomuchdesign/postcss-nested-ancestors",
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
-    "object-assign": "^4.1.0",
     "postcss": "^5.0.21"
   },
   "devDependencies": {
@@ -29,7 +27,7 @@
     "eslint-config-postcss": "^2.0.2"
   },
   "scripts": {
-    "test": "ava && eslint *.js",
+    "test": "ava",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "build": "babel --out-dir=dist index.js",
-    "test": "nyc ava --reporter=text-lcov",
+    "test": "nyc ava --reporter=lcov",
     "report-coverage": "npm test > coverage.lcov && codecov",
     "preversion": "npm test",
     "version": "git add package.json",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "babel --out-dir=dist index.js",
     "test": "nyc ava --reporter=lcov",
-    "report-coverage": "npm test > coverage.lcov && codecov",
+    "report-coverage": "npm report --reporter=lcov > coverage.lcov && codecov",
     "preversion": "npm test",
     "version": "git add package.json",
     "postversion": "git push && git push --tags"

--- a/test.js
+++ b/test.js
@@ -85,8 +85,8 @@ test('Replace ancestors at different nesting levels', t => {
 
 test('Replace ancestors with 4 different hierarchy levels (1 exceeding)', t => {
     return run( t,
-                '.a{ &-b{ &-c{ &-d{} ^&-d,^&-d{} ^^&-d{} ^^^&-d{} } } }',
-                '.a{ &-b{ &-c{ &-d{} .a-b-d,.a-b-d{} .a-d{} -d{} } } }',
+                '.a{ &-b{ &-c{ &-d{} ^&-d, ^&-d{} ^^&-d{} ^^^&-d{} } } }',
+                '.a{ &-b{ &-c{ &-d{} .a-b-d, .a-b-d{} .a-d{} -d{} } } }',
                 { },
                 1
     );
@@ -133,10 +133,28 @@ test('Replace default ancestor with custom levelSymbol and parentSymbol', t => {
     );
 });
 
-test.failing('Complex nesting: ancestors with multiple selectors', t => {
+test('Complex nesting: ancestors with multiple selectors', t => {
     return run( t,
-                '.a,.b{ &:after{ ^&-c{} } }',
-                '.a,.b{ &:after{ .a-c,.b-c{} } }',
+                '.a, .b{ &:after{ ^&-c{} } }',
+                '.a, .b{ &:after{ .a-c, .b-c{} } }',
                 { }
+    );
+});
+
+test('Complex nesting: ancestors with multiple selectors on newlines', t => {
+    return run( t,
+        `.a,
+        .b {
+            &:after {
+                ^&-c,
+                ^&-d {}
+            }
+        }`,
+        `.a, .b {
+            &:after {
+                .a-c, .b-c, .a-d, .b-d {}
+            }
+        }`,
+        { }
     );
 });

--- a/test.js
+++ b/test.js
@@ -1,160 +1,144 @@
 import postcss from 'postcss';
-import test    from 'ava';
+import test from 'ava';
 
 import plugin from './';
 
 function run(t, input, output, opts = { }, warnings = 0) {
-    return postcss([ plugin(opts) ]).process(input)
-        .then( result => {
-            t.deepEqual(result.css, output);
-            t.deepEqual(result.warnings().length, warnings);
-        });
+	return postcss([ plugin(opts) ]).process(input)
+		.then( result => {
+			t.deepEqual(result.css, output);
+			t.deepEqual(result.warnings().length, warnings);
+		});
 }
 
 test('Chain ancestor in a simple case', t => {
-    return run( t,
-                '.a{ &:hover{ ^&-b{} } }',
-                '.a{ &:hover{ .a-b{} } }',
-                { }
-    );
+	return run( t,
+		'.a{ &:hover{ ^&-b{} } }',
+		'.a{ &:hover{ .a-b{} } }',
+		{ }
+	);
 });
 
 test('Prepend ancestor in a simple case', t => {
-    return run( t,
-                '.a{ &:hover{ ^& .b{} } }',
-                '.a{ &:hover{ .a .b{} } }',
-                { }
-    );
+	return run( t,
+		'.a{ &:hover{ ^& .b{} } }',
+		'.a{ &:hover{ .a .b{} } }',
+		{ }
+	);
 });
 
 test('Chain 2 ancestors in double selector', t => {
-    return run( t,
-                '.a{ &:hover{ ^&-b, ^&-c{} } }',
-                '.a{ &:hover{ .a-b, .a-c{} } }',
-                { }
-    );
+	return run( t,
+		'.a{ &:hover{ ^&-b, ^&-c{} } }',
+		'.a{ &:hover{ .a-b, .a-c{} } }',
+		{ }
+	);
 });
 
 test('Prepend 2 ancestors in double selector', t => {
-    return run( t,
-                '.a{ &:hover{ ^& .b, ^& .c{} } }',
-                '.a{ &:hover{ .a .b, .a .c{} } }',
-                { }
-    );
+	return run( t,
+		'.a{ &:hover{ ^& .b, ^& .c{} } }',
+		'.a{ &:hover{ .a .b, .a .c{} } }',
+		{ }
+	);
 });
 
 test('Replace with root comment', t => {
-    return run( t,
-                '/* This is a comment */ .a{ &:hover{ ^& .b, ^& .c{} } }',
-                '/* This is a comment */ .a{ &:hover{ .a .b, .a .c{} } }',
-                { }
-    );
+	return run( t,
+		'/* This is a comment */ .a{ &:hover{ ^& .b, ^& .c{} } }',
+		'/* This is a comment */ .a{ &:hover{ .a .b, .a .c{} } }',
+		{ }
+	);
 });
 
 test('Replace with nested comment', t => {
-    return run( t,
-                '.a{ &:hover{ /* This is a comment */ ^& .b, ^& .c{} } }',
-                '.a{ &:hover{ /* This is a comment */ .a .b, .a .c{} } }',
-                { }
-    );
-});
-
-test('Replace declaration values if replaceValues is true', t => {
-    return run( t,
-                '.a{ &:hover { &:before { content: "^&"; } } }',
-                '.a{ &:hover { &:before { content: ".a:hover"; } } }',
-                { replaceDeclarations: true }
-    );
-});
-
-test('Replace declaration values if replaceDeclarations is true', t => {
-    return run( t,
-                '.a{ &:hover { &:before { content: "^^&"; } } }',
-                '.a{ &:hover { &:before { content: ".a"; } } }',
-                { replaceDeclarations: true }
-    );
+	return run( t,
+		'.a{ &:hover{ /* This is a comment */ ^& .b, ^& .c{} } }',
+		'.a{ &:hover{ /* This is a comment */ .a .b, .a .c{} } }',
+		{ }
+	);
 });
 
 test('Replace ancestors at different nesting levels', t => {
-    return run( t,
-                '.a{ &:hover{ ^&-b{} } .c{ .d{ ^&-e{} } } .z{} }',
-                '.a{ &:hover{ .a-b{} } .c{ .d{ .a .c-e{} } } .z{} }',
-                { }
-    );
+	return run( t,
+		'.a{ &:hover{ ^&-b{} } .c{ .d{ ^&-e{} } } .z{} }',
+		'.a{ &:hover{ .a-b{} } .c{ .d{ .a .c-e{} } } .z{} }',
+		{ }
+	);
 });
 
 test('Replace ancestors with 4 different hierarchy levels (1 exceeding)', t => {
-    return run( t,
-                '.a{ &-b{ &-c{ &-d{} ^&-d, ^&-d{} ^^&-d{} ^^^&-d{} } } }',
-                '.a{ &-b{ &-c{ &-d{} .a-b-d, .a-b-d{} .a-d{} -d{} } } }',
-                { },
-                1
-    );
+	return run( t,
+		'.a{ &-b{ &-c{ &-d{} ^&-d, ^&-d{} ^^&-d{} ^^^&-d{} } } }',
+		'.a{ &-b{ &-c{ &-d{} .a-b-d, .a-b-d{} .a-d{} -d{} } } }',
+		{ },
+		1
+	);
 });
 
 test('Process 2 nested ancestors', t => {
-    return run( t,
-                '.a{ &-b{ &-c{ ^^&-d{ &-e{ ^^^^&-f{ } } } } } }',
-                '.a{ &-b{ &-c{ .a-d{ &-e{ .a-f{ } } } } } }',
-                { }
-    );
+	return run( t,
+		'.a{ &-b{ &-c{ ^^&-d{ &-e{ ^^^^&-f{ } } } } } }',
+		'.a{ &-b{ &-c{ .a-d{ &-e{ .a-f{ } } } } } }',
+		{ }
+	);
 });
 
 test('Process nested ancestor close to > \, + and ~ selectors', t => {
-    return run( t,
-                '.a{ &-b{ > ^&-c{} + ^&-d{} ~ ^&-e{} } }',
-                '.a{ &-b{ > .a-c{} + .a-d{} ~ .a-e{} } }',
-                { }
-    );
+	return run( t,
+		'.a{ &-b{ > ^&-c{} + ^&-d{} ~ ^&-e{} } }',
+		'.a{ &-b{ > .a-c{} + .a-d{} ~ .a-e{} } }',
+		{ }
+	);
 });
 
 test('Return empty string when pointing to a non-existent ancestor', t => {
-    return run( t,
-                '.a{ &-b{ &-c{ ^^^^&-d{} } } }',
-                '.a{ &-b{ &-c{ -d{} } } }',
-                { },
-                1
-    );
+	return run( t,
+		'.a{ &-b{ &-c{ ^^^^&-d{} } } }',
+		'.a{ &-b{ &-c{ -d{} } } }',
+		{ },
+		1
+	);
 });
 
 test('Replace default ancestor selector with \"£%\"', t => {
-    return run( t,
-                '.a{ &-b{ &-c{ ££%-d{ £££%-f{ } } } } }',
-                '.a{ &-b{ &-c{ .a-d{ .a-f{ } } } } }',
-                { placeholder: '£%' }
-    );
+	return run( t,
+		'.a{ &-b{ &-c{ ££%-d{ £££%-f{ } } } } }',
+		'.a{ &-b{ &-c{ .a-d{ .a-f{ } } } } }',
+		{ placeholder: '£%' }
+	);
 });
 
 test('Replace default ancestor with custom levelSymbol and parentSymbol', t => {
-    return run( t,
-                '.a{ &-b{ &-c{ foofoobar-d{ foofoofoobar-f{ } } } } }',
-                '.a{ &-b{ &-c{ .a-d{ .a-f{ } } } } }',
-                { levelSymbol: 'foo', parentSymbol: 'bar' }
-    );
+	return run( t,
+		'.a{ &-b{ &-c{ foofoobar-d{ foofoofoobar-f{ } } } } }',
+		'.a{ &-b{ &-c{ .a-d{ .a-f{ } } } } }',
+		{ levelSymbol: 'foo', parentSymbol: 'bar' }
+	);
 });
 
 test('Complex nesting: ancestors with multiple selectors', t => {
-    return run( t,
-                '.a, .b{ &:after{ ^&-c{} } }',
-                '.a, .b{ &:after{ .a-c, .b-c{} } }',
-                { }
-    );
+	return run( t,
+		'.a, .b{ &:after{ ^&-c{} } }',
+		'.a, .b{ &:after{ .a-c, .b-c{} } }',
+		{ }
+	);
 });
 
 test('Complex nesting: ancestors with multiple selectors on newlines', t => {
-    return run( t,
-        `.a,
-        .b {
-            &:after {
-                ^&-c,
-                ^&-d {}
-            }
-        }`,
-        `.a, .b {
-            &:after {
-                .a-c, .b-c, .a-d, .b-d {}
-            }
-        }`,
-        { }
-    );
+	return run( t,
+		`.a,
+		.b {
+			&:after {
+				^&-c,
+				^&-d {}
+			}
+		}`,
+		`.a, .b {
+			&:after {
+				.a-c, .b-c, .a-d, .b-d {}
+			}
+		}`,
+		{ }
+	);
 });


### PR DESCRIPTION
I believe this resolves the problem of complex nesting. One thing of note is that comma separated selectors are rejoined with a comma and space `, `. I thought this would be satisfactory as part of a greater PostCSS pipeline, but perhaps that will be an issue. You will see that I updated two of your pre-existing tests as a result of this assumption. I hope this helps. 